### PR TITLE
Fix typo in console log message for Ansible check

### DIFF
--- a/topics/ansible/basic/helloworld/ansible-helloworld.sh
+++ b/topics/ansible/basic/helloworld/ansible-helloworld.sh
@@ -13,7 +13,7 @@ check_tool_exist() {
   fi
 }
 
-console_log "Checking if Ansile is installed"
+console_log "Checking if Ansible is installed"
 check_tool_exist
 
 console_log "Checking Ansible version"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This pull request fixes a typo. It changes "Ansile" to "Ansible." Thank you!